### PR TITLE
Replace error with nif_error to help dialyzer to accept that bif functions may return any term

### DIFF
--- a/src/e2qc_nif.erl
+++ b/src/e2qc_nif.erl
@@ -53,7 +53,7 @@ init() ->
 %% @private
 -spec get(Cache :: atom(), Key :: binary()) -> notfound | binary().
 get(_Cache, _Key) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 %% @private
 %% for tests only
@@ -63,32 +63,32 @@ put(Cache, Key, Val) ->
 %% @private
 -spec put(Cache :: atom(), Key :: binary(), Val :: binary(), MaxSize :: integer(), MinQ1Size :: integer()) -> ok.
 put(_Cache, _Key, _Val, _MaxSize, _MinQ1Size) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 %% @private
 -spec put(Cache :: atom(), Key :: binary(), Val :: binary(), MaxSize :: integer(), MinQ1Size :: integer(), Lifetime :: integer()) -> ok.
 put(_Cache, _Key, _Val, _MaxSize, _MinQ1Size, _Lifetime) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 %% @private
 -spec create(Cache :: atom(), MaxSize :: integer(), MinQ1Size :: integer()) -> already_exists | ok.
 create(_Cache, _MaxSize, _MinQ1Size) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 %% @private
 -spec destroy(Cache :: atom()) -> notfound | ok.
 destroy(_Cache) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 %% @private
 -spec destroy(Cache :: atom(), Key :: binary()) -> notfound | ok.
 destroy(_Cache, _Key) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 %% @private
 -spec stats(Cache :: atom()) -> notfound | {Hits :: integer(), Misses :: integer(), Q1Size :: integer(), Q2Size :: integer(), IncrQSize :: integer()}.
 stats(_Cache) ->
-	error(badnif).
+	erlang:nif_error(badnif).
 
 -ifdef(TEST).
 


### PR DESCRIPTION
Without this change, dialyzer will deduce that all the bif functions never returns and therefore will have a return type of 'none()' which can never be matched. (dialyzer cannot see that function are replaced by a nif). The pull request replaces ```error``` with ```nif_error```.

From the erlang documentation (http://www.erlang.org/doc/man/erlang.html#nif_error-1)
```
erlang:nif_error(Reason) -> no_return()

Types:
Reason = term()

Works exactly like erlang:error/1, but Dialyzer thinks that this BIF will return 
an arbitrary term. When used in a stub function for a NIF to generate an 
exception when the NIF library is not loaded, Dialyzer will not generate false
warnings.
```